### PR TITLE
Add support for DBAL Statement executions

### DIFF
--- a/src/ZipkinDoctrine/Statement.php
+++ b/src/ZipkinDoctrine/Statement.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ZipkinDoctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Statement as DBALStatement;
+use Zipkin\Tracer;
+use Zipkin\Tags;
+
+class Statement extends DBALStatement
+{
+    /**
+     * @var Tracer
+     */
+    private $tracer;
+
+    public function __construct($sql, Connection $conn, Tracer $tracer)
+    {
+        parent::__construct($sql, $conn);
+        $this->tracer = $tracer;
+    }
+
+    /**
+     * {@inhertidoc}
+     */
+    public function execute($params = null)
+    {
+        $span = $this->tracer->nextSpan();
+        $span->setName('sql/execute');
+        $span->tag(Tags\SQL_QUERY, $this->sql);
+
+        try {
+            $span->start();
+            $result = parent::execute($params);
+            if ($result === false) {
+                $span->tag(Tags\ERROR, "1");
+            }
+
+            return $result;
+        } catch (DBALException $e) {
+            $span->tag(Tags\ERROR, $e->getMessage());
+            throw $e;
+        } finally {
+            $span->finish();
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces support to trace DBAL Statement executions, as the connection used to execute Statements is not the same one you had already instrumented in this library. See [this](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Statement.php#L71) for further reference